### PR TITLE
Work in Progress: Continue camera run when tab change

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,6 +116,7 @@ dependencies {
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"
     implementation "androidx.camera:camera-view:${camerax_version}"
+    implementation "androidx.lifecycle:lifecycle-service:2.0.0"
 
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,6 +125,7 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
+        <service android:name=".camera.service.ImageAnalyseService"/>
     </application>
     <queries>
         <!-- Opening web links -->

--- a/app/src/main/java/de/rwth_aachen/phyphox/ExpView.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/ExpView.java
@@ -2448,9 +2448,10 @@ public class ExpView implements Serializable{
            super.createView(ll, c, res, parent, experiment);
            this.parent = parent;
 
-            LayoutInflater inflater = LayoutInflater.from(c);
-            View inflateView = inflater.inflate(R.layout.camera_layout, ll, true);
-            FragmentContainerView containerView = inflateView.findViewById(R.id.fragmetContainerView);
+
+           // LayoutInflater inflater = LayoutInflater.from(c);
+            //View inflateView = inflater.inflate(R.layout.camera_layout, ll, true);
+            //FragmentContainerView containerView = inflateView.findViewById(R.id.fragmetContainerView);
             cameraPreviewFragment = new CameraPreviewFragment();
             FragmentManager fragmentManager = parent.getChildFragmentManager();
             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
@@ -2461,7 +2462,8 @@ public class ExpView implements Serializable{
             args.putSerializable(CameraHelper.EXPERIMENT_ARG, experiment);
             cameraPreviewFragment.setArguments(args);
 
-            fragmentTransaction.add(containerView.getId(), cameraPreviewFragment);
+            //Log.d("ExpViewFragment", "createView ExpView id: "+containerView.getId());
+            fragmentTransaction.add(ll.getId(), cameraPreviewFragment);
             fragmentTransaction.addToBackStack(null);
             fragmentTransaction.commit();
 

--- a/app/src/main/java/de/rwth_aachen/phyphox/camera/helper/ImageAnalyser.kt
+++ b/app/src/main/java/de/rwth_aachen/phyphox/camera/helper/ImageAnalyser.kt
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 class ImageAnalyser(private val cameraViewModel: CameraViewModel) : ImageAnalysis.Analyzer {
 
+    private var TAG = "ImageAnalyser"
     private var lastAnalyzedTimestamp = 0L
     private var photometricReader: PhotometricReader = PhotometricReader()
 
@@ -74,6 +75,8 @@ class ImageAnalyser(private val cameraViewModel: CameraViewModel) : ImageAnalysi
 
         // 63 is the value when there is full dark, so substracting with 60
         val brightnessPercentage = (((brightness - 60.0)/ 255.0) * 100.0)
+
+        Log.d(TAG, "brightnessPercentage: "+brightnessPercentage)
 
         val t: Double =
             cameraViewModel.cameraInput.experimentTimeReference.getExperimentTimeFromEvent(

--- a/app/src/main/java/de/rwth_aachen/phyphox/camera/model/CameraProperties.kt
+++ b/app/src/main/java/de/rwth_aachen/phyphox/camera/model/CameraProperties.kt
@@ -1,0 +1,66 @@
+package de.rwth_aachen.phyphox.camera.model
+
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.camera.view.PreviewView
+
+class CameraProperties() : Parcelable {
+
+    private var cameraSettingLevel = CameraSettingLevel.BASIC
+
+    private var exposure: Int = 0
+
+    private var iso: Int = 0
+    private var shutterSpeed : Long = 0L
+    private var aperture: Float = 0.0f
+
+    private var whiteBalanceValues : MutableList<Float> = mutableListOf()
+    private var whiteBalanceMode : Int = 0
+
+    constructor(
+        cameraSettingLevel: CameraSettingLevel,
+        exposure: Int
+    ) : this() {
+        this.cameraSettingLevel = cameraSettingLevel
+        this.exposure = exposure
+    }
+
+    constructor(
+        cameraSettingLevel: CameraSettingLevel,
+        iso: Int,
+        shutterSpeed: Long,
+        aperture: Float,
+        whiteBalanceValue: MutableList<Float>,
+        whiteBalanceMode: Int
+    ) : this() {
+        this.cameraSettingLevel = cameraSettingLevel
+        this.iso = iso
+        this.shutterSpeed = shutterSpeed
+        this.aperture = aperture
+        this.whiteBalanceValues = whiteBalanceValue
+        this.whiteBalanceMode  = whiteBalanceMode
+
+    }
+
+    constructor(parcel: Parcel) : this() {
+        //cameraSettingLevel = parcel.readInt()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<CameraProperties> {
+        override fun createFromParcel(parcel: Parcel): CameraProperties {
+            return CameraProperties(parcel)
+        }
+
+        override fun newArray(size: Int): Array<CameraProperties?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/app/src/main/java/de/rwth_aachen/phyphox/camera/service/CameraCallback.kt
+++ b/app/src/main/java/de/rwth_aachen/phyphox/camera/service/CameraCallback.kt
@@ -1,0 +1,7 @@
+package de.rwth_aachen.phyphox.camera.service
+
+import androidx.camera.view.PreviewView
+
+interface CameraCallback {
+        fun onSetupCameraPreview(previewView: PreviewView)
+}

--- a/app/src/main/java/de/rwth_aachen/phyphox/camera/service/CameraServiceLiveData.kt
+++ b/app/src/main/java/de/rwth_aachen/phyphox/camera/service/CameraServiceLiveData.kt
@@ -1,0 +1,23 @@
+package de.rwth_aachen.phyphox.camera.service
+
+import android.util.Log
+import androidx.camera.view.PreviewView
+import androidx.lifecycle.LiveData
+
+class CameraServiceLiveData private constructor() : LiveData<PreviewView?>() {
+
+    companion object {
+        @Volatile
+        private var instance: CameraServiceLiveData? = null
+
+        fun getInstance(): CameraServiceLiveData {
+            return instance ?: synchronized(this) {
+                instance ?: CameraServiceLiveData().also { instance = it }
+            }
+        }
+    }
+
+    fun postCustomObject(data: PreviewView?) {
+        value = data
+    }
+}

--- a/app/src/main/java/de/rwth_aachen/phyphox/camera/service/ImageAnalyseService.kt
+++ b/app/src/main/java/de/rwth_aachen/phyphox/camera/service/ImageAnalyseService.kt
@@ -1,0 +1,129 @@
+package de.rwth_aachen.phyphox.camera.service
+
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.camera.core.Camera
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.launch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+class ImageAnalyseService: LifecycleService(), CameraCallback {
+
+    private lateinit var cameraProviderListenableFuture:  ListenableFuture<ProcessCameraProvider>
+    private lateinit var processCameraProvider: ProcessCameraProvider
+    private lateinit var imageAnalysis: ImageAnalysis
+    private val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val imageAnalyser: ImageAnalyserTemp = ImageAnalyserTemp()
+
+    var camera: Camera? = null
+    lateinit var preview: Preview
+
+    var previewView: PreviewView? = null
+
+
+    override fun onCreate() {
+        super.onCreate()
+        listenToLiveData()
+        initializeCamera()
+
+    }
+
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+
+        //listenForCameraInstantiation()
+        return START_STICKY
+    }
+
+    private fun listenToLiveData(){
+        Log.d("CameraServiceLiveData", "listenToLiveData")
+        CameraServiceLiveData.getInstance().observe(this) { t ->
+            if (t != null) {
+                previewView = t
+                listenForCameraInstantiation()
+            }
+        }
+    }
+
+    private fun initializeCamera(){
+        cameraProviderListenableFuture = ProcessCameraProvider.getInstance(application)
+    }
+
+    private fun listenForCameraInstantiation(){
+
+            cameraProviderListenableFuture = ProcessCameraProvider.getInstance(this@ImageAnalyseService)
+
+            cameraProviderListenableFuture.addListener({
+                try {
+                    processCameraProvider = cameraProviderListenableFuture.get()
+                    (processCameraProvider as ProcessCameraProvider?)?.let {
+                        startCamera(it)
+                    }
+                } catch (e: ExecutionException) {
+                    e.printStackTrace()
+                } catch (e: InterruptedException) {
+                    e.printStackTrace()
+                }
+            }, ContextCompat.getMainExecutor(this@ImageAnalyseService))
+
+    }
+
+
+    private fun startCamera(cameraProvider: ProcessCameraProvider){
+        cameraProvider.unbindAll()
+        val cameraSelector =  CameraSelector.DEFAULT_BACK_CAMERA
+
+        preview = Preview.Builder().build().also {
+            it.setSurfaceProvider(previewView?.surfaceProvider)
+        }
+
+        imageAnalysis = ImageAnalysis.Builder()
+            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+            .build()
+
+        imageAnalysis.setAnalyzer(cameraExecutor, imageAnalyser)
+
+        if(lifecycle.currentState != Lifecycle.State.DESTROYED)
+            cameraProvider.bindToLifecycle(this@ImageAnalyseService, cameraSelector, preview, imageAnalysis)
+
+    }
+
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+    }
+
+    override fun onSetupCameraPreview(previewView: PreviewView) {
+       this.previewView = previewView
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+@androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
+class ImageAnalyserTemp: ImageAnalysis.Analyzer {
+    override fun  analyze(image: ImageProxy) {
+        val mediaImage = image.image!!
+        Log.d("ImageAnalyserTemp", "image: pixelStride "+mediaImage.planes[0].pixelStride)
+        image.close()
+
+    }
+
+}

--- a/app/src/main/res/layout/camera_layout.xml
+++ b/app/src/main/res/layout/camera_layout.xml
@@ -5,16 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/text2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="10dp"
-        android:text="Camera Preview"
-        app:layout_constraintBottom_toTopOf="@+id/fragmetContainerView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmetContainerView"


### PR DESCRIPTION
Done:
- Fix of the crash when changing the tab which has camera fragment.
- Introduce lifecycleService to run the camera in the Service.
- Refactor the camera operation in this lifecycle

ToDo:
- After introducing the LifecycleService, the camera still recreating new instance so the image analysis is not running continuously.