### PR TITLE
Upgrade RemoteServer and move to JLHTTP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    useLibrary 'org.apache.http.legacy'
     namespace 'de.rwth_aachen.phyphox'
     testNamespace 'de.rwth_aachen.phyphoxTest'
 
@@ -94,6 +93,8 @@ dependencies {
 
     //https://poi.apache.org/changes.html
     implementation 'org.apache.poi:poi:3.13'
+
+    implementation 'net.freeutils:jlhttp:3.1'
 
     //https://bigbadaboom.github.io/androidsvg/release_notes.html
     implementation 'com.caverock:androidsvg:1.4'

--- a/app/src/main/java/de/rwth_aachen/phyphox/Experiment.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/Experiment.java
@@ -1935,16 +1935,8 @@ public class Experiment extends AppCompatActivity implements View.OnClickListene
             return;
 
         //Stop it!
-        remote.stopServer();
-
-        //Wait for the second thread and remove the instance
-        try {
-            remote.join();
-        } catch (Exception e) {
-            Log.e("stopRemoteServer", "Exception on join.", e);
-        }
+        remote.stop();
         remote = null;
-
     }
 
     //Called by remote server to stop the measurement from other thread

--- a/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
@@ -825,7 +825,7 @@ public class RemoteServer extends Thread {
             int formatInt = Integer.parseInt(format);
             if (formatInt < 0 || formatInt >= experiment.exporter.exportFormats.length) {
                 //Not good. Build an error entity
-                respond(response, "{\"error\" = \"Format out of range.\"}");
+                respond(response, "{\"error\": \"Format out of range.\"}");
             } else {
                 //Alright, let's go on with the export
 
@@ -1034,10 +1034,10 @@ public class RemoteServer extends Thread {
                     File file = new File(experiment.resourceFolder, src);
                     respond(response, null, file);
                 } catch (Exception e) {
-                    respond(response, "{\"error\" = \"Unknown file.\"}");
+                    respond(response, "{\"error\": \"Unknown file.\"}");
                 }
             } else {
-                respond(response, "{\"error\" = \"Unknown file.\"}");
+                respond(response, "{\"error\": \"Unknown file.\"}");
             }
         }
 

--- a/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
@@ -66,8 +66,8 @@ import java.util.Set;
 import java.util.Vector;
 
 //remoteServer implements a web-interface to remote control the experiment and receive the data
-//Unfortunately, Google decided to depricate org.apache.http in Android 6, so until we move to
-//something else, we need to suppress deprication warnings if we do not want to get flooded.
+//Unfortunately, Google decided to deprecate org.apache.http in Android 6, so until we move to
+//something else, we need to suppress deprecation warnings if we do not want to get flooded.
 
 @SuppressWarnings( "deprecation" )
 public class RemoteServer extends Thread {
@@ -83,7 +83,7 @@ public class RemoteServer extends Thread {
 
     public String sessionID = "";
 
-    public boolean forceFullUpdate = false; //Something has happened (clear) that makes it neccessary to force a full buffer update to the remote interface
+    public boolean forceFullUpdate = false; //Something has happened (clear) that makes it necessary to force a full buffer update to the remote interface
 
     static String indexHTML, styleCSS; //These strings will hold the html and css document when loaded from our resources
 
@@ -220,9 +220,9 @@ public class RemoteServer extends Thread {
                     htmlID2Element.clear();
 
                     for (int i = 0; i < experiment.experimentViews.size(); i++) {
-                        //For each ecperiment view
+                        //For each experiment view
 
-                        if (i > 0)  //Add a colon if this is not the first item to seperate the previous one.
+                        if (i > 0)  //Add a colon if this is not the first item to separate the previous one.
                             sb.append(",\n"); //Not necessary, but debugging is so much more fun with a line-break.
 
                         //The name of this view
@@ -238,7 +238,7 @@ public class RemoteServer extends Thread {
                             htmlID2View.add(i);
                             htmlID2Element.add(j);
 
-                            if (j > 0)  //Add a colon if this is not the first item to seperate the previous one.
+                            if (j > 0)  //Add a colon if this is not the first item to separate the previous one.
                                 sb.append(",");
 
                             //The element's label
@@ -340,7 +340,7 @@ public class RemoteServer extends Thread {
         this(experiment, callActivity, String.format("%06x", (System.nanoTime() & 0xffffff)));
     }
 
-    //This helper function lists all external IP adresses, so the user can be told, how to reach the webinterface
+    //This helper function lists all external IP addresses, so the user can be told, how to reach the webinterface
     public static String getAddresses(Context context) {
         String ret = "";
         Inet4Address filterMobile = null;
@@ -368,7 +368,7 @@ public class RemoteServer extends Thread {
             while (enumNetworkInterfaces.hasMoreElements()) { //For each network interface
                 NetworkInterface networkInterface = enumNetworkInterfaces.nextElement();
                 Enumeration<InetAddress> enumInetAddress = networkInterface.getInetAddresses();
-                while (enumInetAddress.hasMoreElements()) { //For each adress of this interface
+                while (enumInetAddress.hasMoreElements()) { //For each address of this interface
                     InetAddress inetAddress = enumInetAddress.nextElement();
 
                     //We want non-local, non-loopback IPv4 addresses (nobody really uses IPv6 on local networks and phyphox is not supposed to run over the internet - let's not make it too complicated for the user)
@@ -381,7 +381,7 @@ public class RemoteServer extends Thread {
             }
 
         } catch (SocketException e) {
-            Log.e("getAdresses", "Error getting the IP.", e);
+            Log.e("getAddresses", "Error getting the IP.", e);
         }
         return ret;
     }
@@ -466,7 +466,7 @@ public class RemoteServer extends Thread {
     }
 
 
-    //Stop the server by siply setting RUNNING to false
+    //Stop the server by simply setting RUNNING to false
     public synchronized void stopServer() {
         RUNNING = false;
     }
@@ -617,7 +617,7 @@ public class RemoteServer extends Thread {
                     if (firstBuffer)
                         firstBuffer = false;
                     else
-                        sb.append(",\n"); //Seperate the object with a comma, if this is not the first item
+                        sb.append(",\n"); //Separate the object with a comma, if this is not the first item
 
                     //Get the threshold reference data buffer
                     DataBuffer db_reference;
@@ -651,7 +651,7 @@ public class RemoteServer extends Thread {
                             sb.append(format.format(db.value));
                     else {
                         //Get all the values...
-                        boolean firstValue = true; //Find first iteration, so the other ones can add a seperator
+                        boolean firstValue = true; //Find first iteration, so the other ones can add a separator
                         Double data[] = db.getArray();
                         int n = db.getFilledSize();
                         Double dataRef[];
@@ -671,7 +671,7 @@ public class RemoteServer extends Thread {
                             if (v_dep <= buffer.threshold) //Skip this value if it is below the threshold or NaN
                                 continue;
 
-                            //Add a seperator if this is not the first value
+                            //Add a separator if this is not the first value
                             if (firstValue)
                                 firstValue = false;
                             else
@@ -767,10 +767,10 @@ public class RemoteServer extends Thread {
                                 callActivity.remoteInput = true;
                                 experiment.newData = true;
 
-                                //Defocus the input element in the API interface or it might not be updated and will reenter the old value
+                                //Defocus the input element in the API interface otherwise it might not be updated and will reenter the old value
                                 callActivity.requestDefocus();
 
-                                //Send the value to the buffer, but aquire a lock first, so it does not interfere with data analysis
+                                //Send the value to the buffer, but acquire a lock first, so it does not interfere with data analysis
                                 experiment.dataLock.lock();
                                 try {
                                     experiment.getBuffer(buffer).append(v);

--- a/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
@@ -10,7 +10,6 @@ import android.net.LinkAddress;
 import android.net.LinkProperties;
 import android.net.Network;
 import android.net.NetworkCapabilities;
-import android.net.Uri;
 import android.os.Build;
 import android.util.Base64;
 import android.util.Log;
@@ -18,24 +17,9 @@ import android.util.Log;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.preference.PreferenceManager;
 
-import org.apache.http.HttpException;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.impl.DefaultConnectionReuseStrategy;
-import org.apache.http.impl.DefaultHttpResponseFactory;
-import org.apache.http.impl.DefaultHttpServerConnection;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.BasicHttpProcessor;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpRequestHandler;
-import org.apache.http.protocol.HttpRequestHandlerRegistry;
-import org.apache.http.protocol.HttpService;
-import org.apache.http.protocol.ResponseConnControl;
-import org.apache.http.protocol.ResponseContent;
-import org.apache.http.protocol.ResponseDate;
-import org.apache.http.protocol.ResponseServer;
+import net.freeutils.httpserver.HTTPServer;
+import net.freeutils.httpserver.HTTPServer.Request;
+import net.freeutils.httpserver.HTTPServer.Response;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -45,38 +29,33 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.Vector;
 
-//remoteServer implements a web-interface to remote control the experiment and receive the data
-//Unfortunately, Google decided to deprecate org.apache.http in Android 6, so until we move to
-//something else, we need to suppress deprecation warnings if we do not want to get flooded.
+//RemoteServer implements a web interface to remote control the experiment and receive the data
 
-@SuppressWarnings( "deprecation" )
-public class RemoteServer extends Thread {
+public class RemoteServer {
 
     private final PhyphoxExperiment experiment; //Reference to the experiment we want to control
 
-    HttpService httpService; //Holds our http service
-    BasicHttpContext basicHttpContext; //A simple http context...
+    HTTPServer httpServer; //Holds our http service
+    ExecutorService executor;
     static int httpServerPort = 8080; //We have to pick a high port number. We may not use 80...
-    boolean RUNNING = false; //Keeps the main loop alive...
     Context context; //Resource reference for comfortable access
     Experiment callActivity; //Reference to the parent activity. Needed to provide its status on the webinterface
 
@@ -323,10 +302,6 @@ public class RemoteServer extends Thread {
         buildIndexHTML();
 
         this.sessionID = sessionID;
-
-        //Start the service...
-        RUNNING = true;
-        startHttpService();
     }
 
     RemoteServer(PhyphoxExperiment experiment, Experiment callActivity) {
@@ -377,153 +352,190 @@ public class RemoteServer extends Thread {
         return ret;
     }
 
-    @Override
-    //This is the main thread, which keeps running in a loop und handles incoming requests.
-    public void run() {
+    //This starts the http server and registers the handlers for several requests
+    public synchronized void start() {
+        httpServerPort = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(context).getString("remoteAccessPort", "8080"));
+        httpServer = new HTTPServer(httpServerPort);
+        executor = Executors.newCachedThreadPool();
+        httpServer.setExecutor(executor);
+        HTTPServer.VirtualHost host = httpServer.getVirtualHost(null);
+
+        //Now register a handler for different requests
+        host.addContext("/", this::handleHome); //The basic interface (index.html) when the user just calls the address
+        host.addContext("/style.css", this::handleStyle); //The style sheet (style.css) linked from index.html
+        host.addContext("/logo", this::handleLogo); //The phyphox logo, also included in style.css
+        host.addContext("/get", this::handleGet); //A get command takes parameters which define, which buffers and how much of them is requested - the response is a JSON set with the data
+        host.addContext("/control", this::handleControl, "GET", "POST"); //The control command starts and stops measurements
+        host.addContext("/export", this::handleExport); //The export command requests a data file containing sets as requested by the parameters
+        host.addContext("/config", this::handleConfig); //The config command requests information on the currently active experiment configuration
+        host.addContext("/meta", this::handleMeta); //The meta command requests information on the device
+        host.addContext("/time", this::handleTime); //The meta command requests information on the current time reference
+        host.addContext("/res", this::handleRes); //Fetch resource files (like images embedded in the experiment configuration)
         try {
-            //Setup server socket
-            ServerSocket serverSocket = new ServerSocket(httpServerPort);
-            serverSocket.setReuseAddress(true);
-            serverSocket.setSoTimeout(3000);
-
-            //The actual loop
-            while (RUNNING) {
-                try {
-                    //Wait for an incoming connection and accept it as a socket instance
-                    Socket socket = serverSocket.accept();
-
-                    //Turn this into a http server connection
-                    DefaultHttpServerConnection httpServerConnection = new DefaultHttpServerConnection();
-                    try {
-                        //Take the connection
-                        httpServerConnection.bind(socket, new BasicHttpParams());
-                        //Do what has been requested and answer (see handle registry below)
-                        //while (httpServerConnection.isOpen() && RUNNING) {
-                            httpService.handleRequest(httpServerConnection, basicHttpContext);
-                        //}
-                        //Note about the commented while-loop:
-                        //In theory, this loop should improve performance by allowing persistent connections, but for some reason many requests
-                        //fail if they are send in rapid succession. Not sure why... One idea is, that the second request is send while the first
-                        //one is still being handled and hence entirely ignored. If we close the connection instead, the browser is forced to
-                        //send it again at a more convenient timing... Not entirely convinced. For now let's use the version that works better...
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    } finally {
-                        httpServerConnection.shutdown();
-                    }
-                } catch (SocketTimeoutException e) {
-                    //A timeout is ok. We will just start listening again
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-            //The loop has been shut down, so close our server socket
-            serverSocket.close();
+            httpServer.start();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
-
-    //This starts the http service and registers the handlers for several requests
-    private synchronized void startHttpService() {
-        httpServerPort = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(context).getString("remoteAccessPort", "8080"));
-
-        BasicHttpProcessor basicHttpProcessor = new BasicHttpProcessor();
-        basicHttpContext = new BasicHttpContext();
-
-        basicHttpProcessor.addInterceptor(new ResponseDate());
-        basicHttpProcessor.addInterceptor(new ResponseServer());
-        basicHttpProcessor.addInterceptor(new ResponseContent());
-        basicHttpProcessor.addInterceptor(new ResponseConnControl());
-
-        httpService = new HttpService(basicHttpProcessor,
-                new DefaultConnectionReuseStrategy(),
-                new DefaultHttpResponseFactory());
-
-        //Now register a handler for different requests
-        HttpRequestHandlerRegistry registry = new HttpRequestHandlerRegistry();
-        registry.register("/", new HomeCommandHandler()); //The basic interface (index.html) when the user just calls the address
-        registry.register("/style.css", new StyleCommandHandler()); //The style sheet (style.css) linked from index.html
-        registry.register("/logo", new LogoHandler()); //The phyphox logo, also included in style.css
-        registry.register("/get", new GetCommandHandler()); //A get command takes parameters which define, which buffers and how much of them is requested - the response is a JSON set with the data
-        registry.register("/control", new ControlCommandHandler()); //The control command starts and stops measurements
-        registry.register("/export", new ExportCommandHandler()); //The export command requests a data file containing sets as requested by the parameters
-        registry.register("/config", new ConfigCommandHandler()); //The config command requests information on the currently active experiment configuration
-        registry.register("/meta", new MetaCommandHandler()); //The meta command requests information on the device
-        registry.register("/time", new TimeCommandHandler()); //The meta command requests information on the current time reference
-        registry.register("/res", new ResCommandHandler()); //Fetch resource files (like images embedded in the experiment configuration)
-        httpService.setHandlerResolver(registry);
-    }
-
-
     //Stop the server by simply setting RUNNING to false
-    public synchronized void stopServer() {
-        RUNNING = false;
+    public synchronized void stop() {
+        httpServer.stop();
+        executor.shutdown();
     }
 
-    protected void respond(HttpResponse response, String contentType, InputStream in, long length) {
-        BasicHttpEntity entity = new BasicHttpEntity();
-        entity.setContent(in);
-        if (length > -1)
-            entity.setContentLength(length);
-        //Set the header and THEN send the file
-        if (contentType != null)
-            response.setHeader("Content-Type", contentType);
-        response.setEntity(entity);
+    protected int respond(Response response, String contentType, InputStream in, long length) throws IOException {
+        try {
+            response.sendHeaders(200, length, System.currentTimeMillis(), null, contentType, null);
+            response.sendBody(in, -1, null);
+        } finally {
+            in.close();
+        }
+        return 0; // response fully handled
     }
 
-    protected void respond(HttpResponse response, String contentType, String content) {
+    protected int respond(Response response, String contentType, String content) throws IOException {
         byte[] bytes = content.getBytes();
         InputStream in = new ByteArrayInputStream(bytes);
-        respond(response, contentType, in, bytes.length);
+        return respond(response, contentType, in, bytes.length);
     }
 
-    protected void respond(HttpResponse response, String contentType, File content) throws FileNotFoundException {
+    protected int respond(Response response, String contentType, File content) throws IOException {
         InputStream in = new FileInputStream(content);
-        respond(response, contentType, in, content.length());
+        return respond(response, contentType, in, content.length());
     }
 
-    protected void respond(HttpResponse response, String json) {
-        respond(response, "application/json", json);
+    protected int respond(Response response, String json) throws IOException {
+        return respond(response, "application/json", json);
     }
 
-    protected void respond(HttpResponse response, boolean result) {
-        respond(response, result ? "{\"result\": true}" : "{\"result\": false}");
+    protected int respond(Response response, boolean result) throws IOException {
+        return respond(response, result ? "{\"result\": true}" : "{\"result\": false}");
     }
 
     //The home handler simply sends the already compiled index.html
-    class HomeCommandHandler implements HttpRequestHandler {
-
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-            respond(response, "text/html", indexHTML);
-        }
-
+    public int handleHome(Request request, Response response) throws IOException {
+        return respond(response, "text/html", indexHTML);
     }
 
     //The style handler simply sends the already compiled style.css
-    class StyleCommandHandler implements HttpRequestHandler {
-
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-            respond(response, "text/css", styleCSS);
-        }
-
+    public int handleStyle(Request request, Response response) throws IOException {
+        return respond(response, "text/css", styleCSS);
     }
 
     //The logo handler simply reads the logo from resources and sends it
-    class LogoHandler implements HttpRequestHandler {
+    public int handleLogo(Request request, Response response) throws IOException {
+        InputStream inputStream = context.getAssets().open("remote/phyphox_orange.png");
+        return respond(response, "image/png", inputStream, -1);
+    }
 
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-            InputStream inputStream = context.getAssets().open("remote/phyphox_orange.png");
-            respond(response, "image/png", inputStream, -1);
+    //This structure (ok, class) holds one element of the request corresponding to a buffer
+    protected static class BufferRequest {
+        public String name;         //Name of the requested buffer
+        public Double threshold;    //Threshold from which to read data
+        public String reference;    //The buffer to which the threshold should be applied
+    }
+
+    protected BufferRequest parseBufferRequest(String name, String value, boolean forceFullUpdate) {
+        BufferRequest br = new BufferRequest();
+        br.name = name;
+        br.reference = "";
+        if (value == null || value.isEmpty()) {
+            br.threshold = Double.NaN; //No special request - the last value should be ok
+        } else if (value.equals("full") || forceFullUpdate) {
+            br.threshold = Double.NEGATIVE_INFINITY; //Get every single value
+        } else {
+            //So we get a threshold. We just have to figure out the reference buffer
+            int subsplit = value.indexOf('|');
+            if (subsplit == -1)
+                br.threshold = Double.valueOf(value); //No reference specified
+            else { //A reference is given
+                br.threshold = Double.valueOf(value.substring(0, subsplit));
+                br.reference = value.substring(subsplit + 1);
+            }
+            //We only offer 8-digit precision, so we need to move the threshold to avoid receiving a close number multiple times.
+            //Missing something will probably not be visible on a remote graph and a missing value will be recent after stopping anyway.
+            br.threshold += Math.pow(10, Math.floor(Math.log10(br.threshold / 1e7)));
+        }
+        return br;
+    }
+
+    protected Set<BufferRequest> getBufferRequests(Request request) throws IOException {
+        Set<BufferRequest> buffers = new LinkedHashSet<>(); //This list will hold all requests
+        List<String[]> params = request.getParamsList();
+        if (!params.isEmpty()) {
+            for (String[] param : params) {
+                BufferRequest br = parseBufferRequest(param[0], param[1], forceFullUpdate);
+                buffers.add(br);
+            }
+            forceFullUpdate = false;
+        }
+        return buffers;
+    }
+
+    protected void buildBuffer(BufferRequest buffer, DataBuffer db, DecimalFormat format, StringBuilder sb) {
+        //Get the threshold reference data buffer
+        DataBuffer db_reference = buffer.reference.isEmpty() ? db : experiment.getBuffer(buffer.reference);
+
+        //Buffer name
+        sb.append("\"");
+        sb.append(db.name);
+
+        //Buffer size
+        sb.append("\":{\"size\":");
+        sb.append(db.size);
+
+        //Does the response contain a single value, the whole buffer or a part of it?
+        sb.append(",\"updateMode\":\"");
+        if (Double.isNaN(buffer.threshold))
+            sb.append("single");
+        else if (Double.isInfinite(buffer.threshold))
+            sb.append("full");
+        else
+            sb.append("partial");
+        sb.append("\", \"buffer\":[");
+
+        if (Double.isNaN(buffer.threshold)) //Single value. Get the last one directly from our buffer class
+            if (Double.isNaN(db.value) || Double.isInfinite(db.value))
+                sb.append("null");
+            else
+                sb.append(format.format(db.value));
+        else {
+            //Get all the values...
+            boolean firstValue = true; //Find first iteration, so the other ones can add a separator
+            Double[] data = db.getArray();
+            int n = db.getFilledSize();
+            Double[] dataRef;
+            if (db_reference == db)
+                dataRef = data;
+            else {
+                dataRef = db_reference.getArray();
+                n = Math.min(n, db_reference.getFilledSize());
+            }
+
+
+            Double v;
+            for (int i = 0; i < n; i++) {
+                //Simultaneously get the values from both iterators
+                v = data[i];
+                Double v_dep = dataRef[i];
+                if (v_dep <= buffer.threshold) //Skip this value if it is below the threshold or NaN
+                    continue;
+
+                //Add a separator if this is not the first value
+                if (firstValue)
+                    firstValue = false;
+                else
+                    sb.append(",");
+
+                if (Double.isNaN(v) || Double.isInfinite(v))
+                    sb.append("null");
+                else
+                    sb.append(format.format(v));
+            }
         }
 
+        sb.append("]}");
     }
 
     //The get query has the form
@@ -532,511 +544,344 @@ public class RemoteServer extends Thread {
     // values from buffer3 at indices at which values of buffer2 are greater than 67890
     //Example: If you have a graph of sensor data y against time t and already have data to
     // 20 seconds, you would request t=20 and y=20|t to receive any data beyond 20 seconds
-    class GetCommandHandler implements HttpRequestHandler {
+    public int handleGet(Request request, Response response) throws IOException {
+        Set<BufferRequest> buffers = getBufferRequests(request);
 
-        //This structure (ok, class) holds one element of the request corresponding to a buffer
-        protected class BufferRequest {
-            public String name;         //Name of the requested buffer
-            public Double threshold;    //Threshold from which to read data
-            public String reference;    //The buffer to which the threshold should be applied
-        }
+        //We now know what the query request. Let's build our answer
+        StringBuilder sb;
 
-        protected BufferRequest parseBufferRequest(String name, String value, boolean forceFullUpdate) {
-            BufferRequest br = new BufferRequest();
-            br.name = name;
-            br.reference = "";
-            if (value == null || value.isEmpty()) {
-                br.threshold = Double.NaN; //No special request - the last value should be ok
-            } else if (value.equals("full") || forceFullUpdate) {
-                br.threshold = Double.NEGATIVE_INFINITY; //Get every single value
-            } else {
-                //So we get a threshold. We just have to figure out the reference buffer
-                int subsplit = value.indexOf('|');
-                if (subsplit == -1)
-                    br.threshold = Double.valueOf(value); //No reference specified
-                else { //A reference is given
-                    br.threshold = Double.valueOf(value.substring(0, subsplit));
-                    br.reference = value.substring(subsplit + 1);
-                }
-                //We only offer 8-digit precision, so we need to move the threshold to avoid receiving a close number multiple times.
-                //Missing something will probably not be visible on a remote graph and a missing value will be recent after stopping anyway.
-                br.threshold += Math.pow(10, Math.floor(Math.log10(br.threshold / 1e7)));
+        //Lock the data, to get a consistent data block
+        experiment.dataLock.lock();
+        try {
+            //First let's take a guess at how much memory we will need
+            int sizeEstimate = 0;
+            for (BufferRequest buffer : buffers) {
+                DataBuffer db = experiment.getBuffer(buffer.name);
+                if (db != null)
+                    sizeEstimate += 14 * db.size + 100;
             }
-            return br;
-        }
 
-        protected Set<BufferRequest> getBufferRequests(HttpRequest request) {
-            Set<BufferRequest> buffers = new LinkedHashSet<>(); //This list will hold all requests
-            Uri uri = Uri.parse(request.getRequestLine().getUri());
-            Set<String> names = uri.getQueryParameterNames();
-            if (!names.isEmpty()) {
-                for (String name : names) {
-                    String value = uri.getQueryParameter(name);
-                    BufferRequest br = parseBufferRequest(name, value, forceFullUpdate);
-                    buffers.add(br);
-                }
-                forceFullUpdate = false;
-            }
-            return buffers;
-        }
+            //Create the string builder
+            sb = new StringBuilder(sizeEstimate);
 
-        protected void buildBuffer(BufferRequest buffer, DataBuffer db, DecimalFormat format, StringBuilder sb) {
-            //Get the threshold reference data buffer
-            DataBuffer db_reference = buffer.reference.isEmpty() ? db : experiment.getBuffer(buffer.reference);
+            boolean firstBuffer = true; //Helper to recognize the first iteration
 
-            //Buffer name
-            sb.append("\"");
-            sb.append(db.name);
+            //Set our decimal format (English to make sure we use decimal points, not comma
+            DecimalFormat format = (DecimalFormat) NumberFormat.getInstance(Locale.ENGLISH);
+            format.applyPattern("0.#######E0");
 
-            //Buffer size
-            sb.append("\":{\"size\":");
-            sb.append(db.size);
-
-            //Does the response contain a single value, the whole buffer or a part of it?
-            sb.append(",\"updateMode\":\"");
-            if (Double.isNaN(buffer.threshold))
-                sb.append("single");
-            else if (Double.isInfinite(buffer.threshold))
-                sb.append("full");
-            else
-                sb.append("partial");
-            sb.append("\", \"buffer\":[");
-
-            if (Double.isNaN(buffer.threshold)) //Single value. Get the last one directly from our buffer class
-                if (Double.isNaN(db.value) || Double.isInfinite(db.value))
-                    sb.append("null");
+            //Start building...
+            sb.append("{\"buffer\":{\n");
+            for (BufferRequest buffer : buffers) {
+                DataBuffer db = experiment.getBuffer(buffer.name);
+                if (db == null)
+                    continue;
+                if (firstBuffer)
+                    firstBuffer = false;
                 else
-                    sb.append(format.format(db.value));
-            else {
-                //Get all the values...
-                boolean firstValue = true; //Find first iteration, so the other ones can add a separator
-                Double[] data = db.getArray();
-                int n = db.getFilledSize();
-                Double[] dataRef;
-                if (db_reference == db)
-                    dataRef = data;
-                else {
-                    dataRef = db_reference.getArray();
-                    n = Math.min(n, db_reference.getFilledSize());
-                }
+                    sb.append(",\n"); //Separate the object with a comma, if this is not the first item
 
-
-                Double v;
-                for (int i = 0; i < n; i++) {
-                    //Simultaneously get the values from both iterators
-                    v = data[i];
-                    Double v_dep = dataRef[i];
-                    if (v_dep <= buffer.threshold) //Skip this value if it is below the threshold or NaN
-                        continue;
-
-                    //Add a separator if this is not the first value
-                    if (firstValue)
-                        firstValue = false;
-                    else
-                        sb.append(",");
-
-                    if (Double.isNaN(v) || Double.isInfinite(v))
-                        sb.append("null");
-                    else
-                        sb.append(format.format(v));
-                }
+                buildBuffer(buffer, db, format, sb);
             }
 
-            sb.append("]}");
+            //We also send the experiment status
+            sb.append("\n},\n\"status\":{\n");
+
+            //Session ID
+            sb.append("\"session\":\"");
+            sb.append(sessionID);
+
+            //Measuring?
+            sb.append("\", \"measuring\":");
+            sb.append(callActivity.measuring);
+
+            //Timed run?
+            sb.append(", \"timedRun\":");
+            sb.append(callActivity.timedRun);
+
+            //Countdown state
+            sb.append(", \"countDown\":");
+            sb.append(callActivity.millisUntilFinished);
+            sb.append("\n}\n}\n");
+        } finally {
+            experiment.dataLock.unlock();
         }
 
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-
-            Set<BufferRequest> buffers = getBufferRequests(request);
-
-            //We now know what the query request. Let's build our answer
-            StringBuilder sb;
-
-            //Lock the data, to get a consistent data block
-            experiment.dataLock.lock();
-            try {
-                //First let's take a guess at how much memory we will need
-                int sizeEstimate = 0;
-                for (BufferRequest buffer : buffers) {
-                    DataBuffer db = experiment.getBuffer(buffer.name);
-                    if (db != null)
-                        sizeEstimate += 14 * db.size + 100;
-                }
-
-                //Create the string builder
-                sb = new StringBuilder(sizeEstimate);
-
-                boolean firstBuffer = true; //Helper to recognize the first iteration
-
-                //Set our decimal format (English to make sure we use decimal points, not comma
-                DecimalFormat format = (DecimalFormat) NumberFormat.getInstance(Locale.ENGLISH);
-                format.applyPattern("0.#######E0");
-
-                //Start building...
-                sb.append("{\"buffer\":{\n");
-                for (BufferRequest buffer : buffers) {
-                    DataBuffer db = experiment.getBuffer(buffer.name);
-                    if (db == null)
-                        continue;
-                    if (firstBuffer)
-                        firstBuffer = false;
-                    else
-                        sb.append(",\n"); //Separate the object with a comma, if this is not the first item
-
-                    buildBuffer(buffer, db, format, sb);
-                }
-
-                //We also send the experiment status
-                sb.append("\n},\n\"status\":{\n");
-
-                //Session ID
-                sb.append("\"session\":\"");
-                sb.append(sessionID);
-
-                //Measuring?
-                sb.append("\", \"measuring\":");
-                sb.append(callActivity.measuring);
-
-                //Timed run?
-                sb.append(", \"timedRun\":");
-                sb.append(callActivity.timedRun);
-
-                //Countdown state
-                sb.append(", \"countDown\":");
-                sb.append(callActivity.millisUntilFinished);
-                sb.append("\n}\n}\n");
-            } finally {
-                experiment.dataLock.unlock();
-            }
-
-            //Done. Build a string and return it as usual
-            respond(response, sb.toString());
-        }
-
+        //Done. Build a string and return it as usual
+        return respond(response, sb.toString());
     }
 
     //This query has the simple form control?cmd=start or control?cmd=set&buffer=name&value=42
     //The first form starts or stops the measurement. The second one sends a user-given value (from
     //an editElement) to a buffer
-    class ControlCommandHandler implements HttpRequestHandler {
+    public int handleControl(Request request, Response response) throws IOException {
+        String cmd = request.getParams().get("cmd");
 
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-
-            Uri uri = Uri.parse(request.getRequestLine().getUri());
-            String cmd = uri.getQueryParameter("cmd");
-
-            if (cmd != null) {
-                switch (cmd) {
-                    case "start": //Start the measurement
-                        callActivity.remoteStartMeasurement();
-                        respond(response, true);
-                        break;
-                    case "stop": //Stop the measurement
-                        callActivity.remoteStopMeasurement();
-                        respond(response, true);
-                        break;
-                    case "clear": //Clear measurement data
-                        callActivity.clearData();
-                        respond(response, true);
-                        break;
-                    case "set": //Set the value of a buffer
-                        String buffer = uri.getQueryParameter("buffer"); //Which buffer?
-                        String value = uri.getQueryParameter("value"); //Which value?
-                        if (buffer != null && value != null) {
-                            double v;
-                            try {
-                                v = Double.valueOf(value);
-                            } catch (Exception e) {
-                                //Invalid input
-                                respond(response, false);
-                                break;
-                            }
-                            if (Double.isNaN(v)) {
-                                //We do not allow to explicitly set NaN. The buffer initially contains NaN and this is probably a mistake
-                                respond(response, false);
-                            } else {
-                                callActivity.remoteInput = true;
-                                experiment.newData = true;
-
-                                //Defocus the input element in the API interface otherwise it might not be updated and will reenter the old value
-                                callActivity.requestDefocus();
-
-                                //Send the value to the buffer, but acquire a lock first, so it does not interfere with data analysis
-                                experiment.dataLock.lock();
-                                try {
-                                    experiment.getBuffer(buffer).append(v);
-                                } finally {
-                                    experiment.dataLock.unlock();
-                                }
-                                respond(response, true);
-                            }
-                        } else
-                            respond(response, false);
-                        break;
-                    case "trigger":
-                        String elementStr = uri.getQueryParameter("element"); //Which element?
-                        if (elementStr != null) {
-                            int htmlID;
-                            try {
-                                htmlID = Integer.valueOf(elementStr);
-                            } catch (Exception e) {
-                                //Invalid input
-                                respond(response, false);
-                                break;
-                            }
-                            experiment.experimentViews.get(htmlID2View.get(htmlID)).elements.get(htmlID2Element.get(htmlID)).trigger();
-                            respond(response, true);
-                        } else {
-                            respond(response, false);
+        if (cmd != null) {
+            switch (cmd) {
+                case "start": //Start the measurement
+                    callActivity.remoteStartMeasurement();
+                    return respond(response, true);
+                case "stop": //Stop the measurement
+                    callActivity.remoteStopMeasurement();
+                    return respond(response, true);
+                case "clear": //Clear measurement data
+                    callActivity.clearData();
+                    return respond(response, true);
+                case "set": //Set the value of a buffer
+                    String buffer = request.getParams().get("buffer"); //Which buffer?
+                    String value = request.getParams().get("value"); //Which value?
+                    if (buffer != null && value != null) {
+                        double v;
+                        try {
+                            v = Double.valueOf(value);
+                        } catch (Exception e) {
+                            //Invalid input
+                            return respond(response, false);
                         }
-                        break;
-                    default:
-                        respond(response, false);
-                        break;
-                }
-            } else
-                respond(response, false);
-        }
+                        if (Double.isNaN(v)) {
+                            //We do not allow to explicitly set NaN. The buffer initially contains NaN and this is probably a mistake
+                            return respond(response, false);
+                        } else {
+                            callActivity.remoteInput = true;
+                            experiment.newData = true;
 
+                            //Defocus the input element in the API interface otherwise it might not be updated and will reenter the old value
+                            callActivity.requestDefocus();
+
+                            //Send the value to the buffer, but acquire a lock first, so it does not interfere with data analysis
+                            experiment.dataLock.lock();
+                            try {
+                                experiment.getBuffer(buffer).append(v);
+                            } finally {
+                                experiment.dataLock.unlock();
+                            }
+                            return respond(response, true);
+                        }
+                    }
+                    return respond(response, false);
+                case "trigger":
+                    String elementStr = request.getParams().get("element"); //Which element?
+                    if (elementStr != null) {
+                        int htmlID;
+                        try {
+                            htmlID = Integer.valueOf(elementStr);
+                        } catch (Exception e) {
+                            //Invalid input
+                            return respond(response, false);
+                        }
+                        experiment.experimentViews.get(htmlID2View.get(htmlID)).elements.get(htmlID2Element.get(htmlID)).trigger();
+                        return respond(response, true);
+                    }
+                    return respond(response, false);
+                default:
+                    return respond(response, false);
+            }
+        } else
+            return respond(response, false);
     }
 
     //The export query has the form export?format=1&set1=On&set3=On
     //format gives the index of the export format selected by the user
     //Any set (set0, set1, set2...) given should be included in this export
-    class ExportCommandHandler implements HttpRequestHandler {
+    public int handleExport(Request request, Response response) throws IOException {
+        //Get the parameters
+        String format = request.getParams().get("format");
 
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
+        int formatInt = Integer.parseInt(format);
+        if (formatInt < 0 || formatInt >= experiment.exporter.exportFormats.length) {
+            //Not good. Build an error entity
+            return respond(response, "{\"error\": \"Format out of range.\"}");
+        } else {
+            //Alright, let's go on with the export
 
-            //Get the parameters
-            Uri uri = Uri.parse(request.getRequestLine().getUri());
-            String format = uri.getQueryParameter("format");
+            //Get the content-type
+            DataExport.ExportFormat exportFormat = experiment.exporter.exportFormats[formatInt];
+            String type = exportFormat.getType(false);
 
-            int formatInt = Integer.parseInt(format);
-            if (formatInt < 0 || formatInt >= experiment.exporter.exportFormats.length) {
-                //Not good. Build an error entity
-                respond(response, "{\"error\": \"Format out of range.\"}");
-            } else {
-                //Alright, let's go on with the export
+            //Use the experiment's exporter to create the file
+            final String fileName = experiment.title.replaceAll("[^0-9a-zA-Z \\-_]", "");
+            final File exportFile = experiment.exporter.exportDirect(exportFormat, callActivity.getCacheDir(), false, fileName.isEmpty() ? "phyphox" :  fileName, context);
 
-                //Get the content-type
-                DataExport.ExportFormat exportFormat = experiment.exporter.exportFormats[formatInt];
-                String type = exportFormat.getType(false);
-
-                //Use the experiment's exporter to create the file
-                final String fileName = experiment.title.replaceAll("[^0-9a-zA-Z \\-_]", "");
-                final File exportFile = experiment.exporter.exportDirect(exportFormat, callActivity.getCacheDir(), false, fileName.isEmpty() ? "phyphox" :  fileName, context);
-
-                //Set "Content-Disposition" to force the browser to handle this as a download with a default file name
-                response.setHeader("Content-Disposition", "attachment; filename=\"" + exportFormat.getFilename(false) + "\"");
-                respond(response, type, exportFile);
-            }
+            //Set "Content-Disposition" to force the browser to handle this as a download with a default file name
+            response.getHeaders().add("Content-Disposition", "attachment; filename=\"" + exportFormat.getFilename(false) + "\"");
+            return respond(response, type, exportFile);
         }
-
     }
 
     //The config query does not take any parameters
     //It returns information on the currently active experiment configuration like title, category, checksum, inputs, buffers, ...
-    class ConfigCommandHandler implements HttpRequestHandler {
+    public int handleConfig(Request request, Response response) throws IOException {
+        try {
+            JSONObject json = new JSONObject();
 
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-            try {
-                JSONObject json = new JSONObject();
+            json.put("crc32", Long.toHexString(experiment.crc32).toLowerCase());
+            json.put("title", experiment.baseTitle);
+            json.put("localTitle", experiment.title);
+            json.put("category", experiment.baseCategory);
+            json.put("localCategory", experiment.category);
 
-                json.put("crc32", Long.toHexString(experiment.crc32).toLowerCase());
-                json.put("title", experiment.baseTitle);
-                json.put("localTitle", experiment.title);
-                json.put("category", experiment.baseCategory);
-                json.put("localCategory", experiment.category);
-
-                JSONArray buffers = new JSONArray();
-                for (DataBuffer buffer : experiment.dataBuffers) {
-                    buffers.put(new JSONObject().put("name", buffer.name).put("size", buffer.size));
-                }
-                json.put("buffers", buffers);
-
-                JSONArray inputs = new JSONArray();
-                if (experiment.audioRecord != null) {
-                    JSONArray outputs = new JSONArray();
-                    outputs.put(new JSONObject().put("out", experiment.micOutput));
-                    if (!experiment.micRateOutput.isEmpty())
-                        outputs.put(new JSONObject().put("rate", experiment.micRateOutput));
-
-                    inputs.put(new JSONObject()
-                            .put("source", "audio")
-                            .put("outputs", outputs)
-                    );
-                }
-                if (experiment.gpsIn != null) {
-                    JSONArray outputs = new JSONArray();
-                    if (experiment.gpsIn.dataLat != null)
-                        outputs.put(new JSONObject().put("lat", experiment.gpsIn.dataLat.name));
-                    if (experiment.gpsIn.dataLon != null)
-                        outputs.put(new JSONObject().put("lon", experiment.gpsIn.dataLon.name));
-                    if (experiment.gpsIn.dataZ != null)
-                        outputs.put(new JSONObject().put("z", experiment.gpsIn.dataZ.name));
-                    if (experiment.gpsIn.dataZWGS84 != null)
-                        outputs.put(new JSONObject().put("zwgs84", experiment.gpsIn.dataZWGS84.name));
-                    if (experiment.gpsIn.dataV != null)
-                        outputs.put(new JSONObject().put("v", experiment.gpsIn.dataV.name));
-                    if (experiment.gpsIn.dataDir != null)
-                        outputs.put(new JSONObject().put("dir", experiment.gpsIn.dataDir.name));
-                    if (experiment.gpsIn.dataT != null)
-                        outputs.put(new JSONObject().put("t", experiment.gpsIn.dataT.name));
-                    if (experiment.gpsIn.dataAccuracy != null)
-                        outputs.put(new JSONObject().put("accuracy", experiment.gpsIn.dataAccuracy.name));
-                    if (experiment.gpsIn.dataZAccuracy != null)
-                        outputs.put(new JSONObject().put("zAccuracy", experiment.gpsIn.dataZAccuracy.name));
-                    if (experiment.gpsIn.dataStatus != null)
-                        outputs.put(new JSONObject().put("status", experiment.gpsIn.dataStatus.name));
-                    if (experiment.gpsIn.dataSatellites != null)
-                        outputs.put(new JSONObject().put("satellites", experiment.gpsIn.dataSatellites.name));
-
-                    inputs.put(new JSONObject()
-                            .put("source", "location")
-                            .put("outputs", outputs)
-                    );
-                }
-                for (SensorInput input : experiment.inputSensors) {
-                    JSONArray outputs = new JSONArray();
-
-                    if (input.dataX != null)
-                        outputs.put(new JSONObject().put("x", input.dataX.name));
-                    if (input.dataY != null)
-                        outputs.put(new JSONObject().put("y", input.dataY.name));
-                    if (input.dataZ != null)
-                        outputs.put(new JSONObject().put("z", input.dataZ.name));
-                    if (input.dataAbs != null)
-                        outputs.put(new JSONObject().put("abs", input.dataAbs.name));
-                    if (input.dataT != null)
-                        outputs.put(new JSONObject().put("t", input.dataT.name));
-                    if (input.dataAccuracy != null)
-                        outputs.put(new JSONObject().put("accuracy", input.dataAccuracy.name));
-
-                    inputs.put(new JSONObject()
-                            .put("source", input.sensorName.name())
-                            .put("outputs", outputs)
-                    );
-                }
-                if (experiment.bluetoothInputs.size() > 0) {
-                    inputs.put(new JSONObject()
-                            .put("source", "bluetooth"));
-                }
-                json.put("inputs", inputs);
-
-                JSONArray export = new JSONArray();
-                for (DataExport.ExportSet set : experiment.exporter.exportSets) {
-                    JSONArray sources = new JSONArray();
-                    for (DataExport.ExportSet.SourceMapping mapping : set.sources) {
-                        sources.put(new JSONObject()
-                                .put("label", mapping.name)
-                                .put("buffer", mapping.source)
-                        );
-                    }
-                    export.put(new JSONObject().put("set", set.name).put("sources", sources));
-                }
-                json.put("export", export);
-
-                respond(response, json.toString());
-            } catch (JSONException e) {
-                Log.e("configHandler", "Error: " + e.getMessage());
-                respond(response, false);
+            JSONArray buffers = new JSONArray();
+            for (DataBuffer buffer : experiment.dataBuffers) {
+                buffers.put(new JSONObject().put("name", buffer.name).put("size", buffer.size));
             }
-        }
+            json.put("buffers", buffers);
 
+            JSONArray inputs = new JSONArray();
+            if (experiment.audioRecord != null) {
+                JSONArray outputs = new JSONArray();
+                outputs.put(new JSONObject().put("out", experiment.micOutput));
+                if (!experiment.micRateOutput.isEmpty())
+                    outputs.put(new JSONObject().put("rate", experiment.micRateOutput));
+
+                inputs.put(new JSONObject()
+                        .put("source", "audio")
+                        .put("outputs", outputs)
+                );
+            }
+            if (experiment.gpsIn != null) {
+                JSONArray outputs = new JSONArray();
+                if (experiment.gpsIn.dataLat != null)
+                    outputs.put(new JSONObject().put("lat", experiment.gpsIn.dataLat.name));
+                if (experiment.gpsIn.dataLon != null)
+                    outputs.put(new JSONObject().put("lon", experiment.gpsIn.dataLon.name));
+                if (experiment.gpsIn.dataZ != null)
+                    outputs.put(new JSONObject().put("z", experiment.gpsIn.dataZ.name));
+                if (experiment.gpsIn.dataZWGS84 != null)
+                    outputs.put(new JSONObject().put("zwgs84", experiment.gpsIn.dataZWGS84.name));
+                if (experiment.gpsIn.dataV != null)
+                    outputs.put(new JSONObject().put("v", experiment.gpsIn.dataV.name));
+                if (experiment.gpsIn.dataDir != null)
+                    outputs.put(new JSONObject().put("dir", experiment.gpsIn.dataDir.name));
+                if (experiment.gpsIn.dataT != null)
+                    outputs.put(new JSONObject().put("t", experiment.gpsIn.dataT.name));
+                if (experiment.gpsIn.dataAccuracy != null)
+                    outputs.put(new JSONObject().put("accuracy", experiment.gpsIn.dataAccuracy.name));
+                if (experiment.gpsIn.dataZAccuracy != null)
+                    outputs.put(new JSONObject().put("zAccuracy", experiment.gpsIn.dataZAccuracy.name));
+                if (experiment.gpsIn.dataStatus != null)
+                    outputs.put(new JSONObject().put("status", experiment.gpsIn.dataStatus.name));
+                if (experiment.gpsIn.dataSatellites != null)
+                    outputs.put(new JSONObject().put("satellites", experiment.gpsIn.dataSatellites.name));
+
+                inputs.put(new JSONObject()
+                        .put("source", "location")
+                        .put("outputs", outputs)
+                );
+            }
+            for (SensorInput input : experiment.inputSensors) {
+                JSONArray outputs = new JSONArray();
+
+                if (input.dataX != null)
+                    outputs.put(new JSONObject().put("x", input.dataX.name));
+                if (input.dataY != null)
+                    outputs.put(new JSONObject().put("y", input.dataY.name));
+                if (input.dataZ != null)
+                    outputs.put(new JSONObject().put("z", input.dataZ.name));
+                if (input.dataAbs != null)
+                    outputs.put(new JSONObject().put("abs", input.dataAbs.name));
+                if (input.dataT != null)
+                    outputs.put(new JSONObject().put("t", input.dataT.name));
+                if (input.dataAccuracy != null)
+                    outputs.put(new JSONObject().put("accuracy", input.dataAccuracy.name));
+
+                inputs.put(new JSONObject()
+                        .put("source", input.sensorName.name())
+                        .put("outputs", outputs)
+                );
+            }
+            if (experiment.bluetoothInputs.size() > 0) {
+                inputs.put(new JSONObject()
+                        .put("source", "bluetooth"));
+            }
+            json.put("inputs", inputs);
+
+            JSONArray export = new JSONArray();
+            for (DataExport.ExportSet set : experiment.exporter.exportSets) {
+                JSONArray sources = new JSONArray();
+                for (DataExport.ExportSet.SourceMapping mapping : set.sources) {
+                    sources.put(new JSONObject()
+                            .put("label", mapping.name)
+                            .put("buffer", mapping.source)
+                    );
+                }
+                export.put(new JSONObject().put("set", set.name).put("sources", sources));
+            }
+            json.put("export", export);
+
+            return respond(response, json.toString());
+        } catch (JSONException e) {
+            Log.e("configHandler", "Error: " + e.getMessage());
+            return respond(response, false);
+        }
     }
 
     //The meta query does not take any parameters
     //It returns information on the currently used device
-    class MetaCommandHandler implements HttpRequestHandler {
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
+    public int handleMeta(Request request, Response response) throws IOException {
+        try {
 
-            try {
-
-                JSONObject deviceJson = new JSONObject();
-                for (Metadata.DeviceMetadata deviceMetadata : Metadata.DeviceMetadata.values()) {
-                    if (deviceMetadata == Metadata.DeviceMetadata.sensorMetadata || deviceMetadata == Metadata.DeviceMetadata.uniqueID)
-                        continue;
-                    String identifier = deviceMetadata.toString();
-                    deviceJson.put(identifier, new Metadata(identifier, context).get(""));
-                }
-
-                JSONObject sensorsJson = new JSONObject();
-                for (SensorInput.SensorName sensor : SensorInput.SensorName.values()) {
-                    JSONObject sensorJson = new JSONObject();
-                    for (Metadata.SensorMetadata sensorMetadata : Metadata.SensorMetadata.values()) {
-                        String identifier = sensorMetadata.toString();
-                        sensorJson.put(identifier, new Metadata(sensor.name()+identifier, context).get(""));
-                    }
-                    sensorsJson.put(sensor.name(), sensorJson);
-                }
-                deviceJson.put("sensors", sensorsJson);
-
-                respond(response, deviceJson.toString());
-            } catch (JSONException e) {
-                Log.e("configHandler", "Error: " + e.getMessage());
-                respond(response, false);
+            JSONObject deviceJson = new JSONObject();
+            for (Metadata.DeviceMetadata deviceMetadata : Metadata.DeviceMetadata.values()) {
+                if (deviceMetadata == Metadata.DeviceMetadata.sensorMetadata || deviceMetadata == Metadata.DeviceMetadata.uniqueID)
+                    continue;
+                String identifier = deviceMetadata.toString();
+                deviceJson.put(identifier, new Metadata(identifier, context).get(""));
             }
+
+            JSONObject sensorsJson = new JSONObject();
+            for (SensorInput.SensorName sensor : SensorInput.SensorName.values()) {
+                JSONObject sensorJson = new JSONObject();
+                for (Metadata.SensorMetadata sensorMetadata : Metadata.SensorMetadata.values()) {
+                    String identifier = sensorMetadata.toString();
+                    sensorJson.put(identifier, new Metadata(sensor.name()+identifier, context).get(""));
+                }
+                sensorsJson.put(sensor.name(), sensorJson);
+            }
+            deviceJson.put("sensors", sensorsJson);
+
+            return respond(response, deviceJson.toString());
+        } catch (JSONException e) {
+            Log.e("configHandler", "Error: " + e.getMessage());
+            return respond(response, false);
         }
     }
 
     //The time query does not take any parameters
     //It returns a list of time reference points, i.e. start and stop times of the current experiment
-    class TimeCommandHandler implements HttpRequestHandler {
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-            try {
+    public int handleTime(Request request, Response response) throws IOException {
+        try {
 
-                JSONArray json = new JSONArray();
-                for (ExperimentTimeReference.TimeMapping timeMapping : experiment.experimentTimeReference.timeMappings) {
-                    JSONObject eventJson = new JSONObject();
-                    eventJson.put("event", timeMapping.event.name());
-                    eventJson.put("experimentTime", timeMapping.experimentTime);
-                    eventJson.put("systemTime", timeMapping.systemTime/1000.);
-                    json.put(eventJson);
-                }
-
-                respond(response, json.toString());
-            } catch (JSONException e) {
-                Log.e("configHandler", "Error: " + e.getMessage());
-                respond(response, false);
+            JSONArray json = new JSONArray();
+            for (ExperimentTimeReference.TimeMapping timeMapping : experiment.experimentTimeReference.timeMappings) {
+                JSONObject eventJson = new JSONObject();
+                eventJson.put("event", timeMapping.event.name());
+                eventJson.put("experimentTime", timeMapping.experimentTime);
+                eventJson.put("systemTime", timeMapping.systemTime/1000.);
+                json.put(eventJson);
             }
+
+            return respond(response, json.toString());
+        } catch (JSONException e) {
+            Log.e("configHandler", "Error: " + e.getMessage());
+            return respond(response, false);
         }
     }
 
     //The res handler serves resource files (like images embedded in the experiment configuration)
-    class ResCommandHandler implements HttpRequestHandler {
-
-        @Override
-        public void handle(HttpRequest request, HttpResponse response,
-                           HttpContext httpContext) throws HttpException, IOException {
-
-            //Get the parameters
-            Uri uri = Uri.parse(request.getRequestLine().getUri());
-            String src = uri.getQueryParameter("src");
-
-            if (src != null && !src.isEmpty() && experiment.resources.contains(src)) {
-                try {
-                    File file = new File(experiment.resourceFolder, src);
-                    respond(response, null, file);
-                } catch (Exception e) {
-                    respond(response, "{\"error\": \"Unknown file.\"}");
-                }
-            } else {
-                respond(response, "{\"error\": \"Unknown file.\"}");
+    public int handleRes(Request request, Response response) throws IOException {
+        //Get the parameters
+        String src = request.getParams().get("src");
+        if (src != null && !src.isEmpty() && experiment.resources.contains(src)) {
+            try {
+                File file = new File(experiment.resourceFolder, src);
+                return respond(response, null, file);
+            } catch (Exception e) {
+                return respond(response, "{\"error\": \"Unknown file.\"}");
             }
+        } else {
+            return respond(response, "{\"error\": \"Unknown file.\"}");
         }
-
     }
 
 }


### PR DESCRIPTION
As the big comment and the top of RemoteServer has been saying for a while now, the org.apache.http server that was built-in in android was deprecated years ago and needs to be replaced. This PR does two things:

1. All commits except the last - this is just cleanup, refactoring and simplification of the RemoteServer that reduces lots of duplicate code and makes it more readable and maintainable. They were made as preparation for migrating to a new server, but don't change the server implementation yet - they can be merged regardless of the last commit.

2. The last commit - replaces the deprecated HTTP server implementation with JLHTTP, which I think is a perfect match:
  - It's extremely lightweight in size and resources: the full jar is about 60K, but with customizations there's lots more that can be shaved off if needed. Very small runtime footprint as well.
  - Very low latency, which is great for the kind of heavy real-time polling used in the web interface and REST api.
  - GPL license just like phyphox.
 
 Disclaimer: I'm the author of JLHTTP, and a fan of phyphox, which is why I thought this would be a perfect match... I had the idea several years ago but only got around to implementing it now. But don't take my somewhat biased suggestion alone - feel free to check out the heavily documented JLHTTP source code and see if you think it's good for phyphox. If not, you can still merge all the cleanup in the previous commits, which will surely help with migration to any other server.

Note 1: This requires first fixing the bug in the web interface of incorrectly encoding the query parameters (I opened a separate PR in that project, and added some cleanup there as well). Since JLHTTP is RFC-compliant, it rejects the invalid encoding.

Note 2: I've had some other thoughts while working through the code about the REST api, namely that it's not very REST-y: it doesn't make proper use of HTTP verbs (everything is just GET) and doesn't use HTTP error codes (everything is 200 with a JSON response). In addition, error handling (other than the status codes) is inconsistent - some places return a result = false flag, some return an error = "message" string, some are swallowed and ignored instead of returning an actual error (e.g. parameter handling). However changing those is a backward-breaking change, so I didn't actually change any functionality at this point. This requires some design decisions on what to implement, and management decisions on when and how to make the breaking change (maybe a major release at some point?). Food for thought.

