### PR TITLE
Add Access-Control-Allow-Origin to remote-access responses

### DIFF
--- a/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
@@ -386,11 +386,8 @@ public class RemoteServer {
 
     protected int respond(Response response, String contentType, InputStream in, long length) throws IOException {
         try {
-            // CORS: allow any origin to read remote-access responses so standalone
-            // browser pages (and bookmarklets served from other origins) can fetch /get etc.
+            // CORS: allow cross-origin browser pages to read remote-access responses.
             response.getHeaders().add("Access-Control-Allow-Origin", "*");
-            response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-            response.getHeaders().add("Access-Control-Allow-Headers", "Content-Type");
             response.sendHeaders(200, length, System.currentTimeMillis(), null, contentType, null);
             response.sendBody(in, -1, null);
         } finally {

--- a/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
+++ b/app/src/main/java/de/rwth_aachen/phyphox/RemoteServer.java
@@ -386,6 +386,11 @@ public class RemoteServer {
 
     protected int respond(Response response, String contentType, InputStream in, long length) throws IOException {
         try {
+            // CORS: allow any origin to read remote-access responses so standalone
+            // browser pages (and bookmarklets served from other origins) can fetch /get etc.
+            response.getHeaders().add("Access-Control-Allow-Origin", "*");
+            response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+            response.getHeaders().add("Access-Control-Allow-Headers", "Content-Type");
             response.sendHeaders(200, length, System.currentTimeMillis(), null, contentType, null);
             response.sendBody(in, -1, null);
         } finally {


### PR DESCRIPTION
Adds `Access-Control-Allow-Origin: *` to all responses served by the
remote-access HTTP server, so cross-origin browser pages can read from
the API.

# Motivation
Lack of CORS headers makes it hard to build standalone dashboards, bookmarklets,websites, or static
HTML tools that talk to a Phyphox phone app even when the user is on the same local network. 

I'm aware this PR may not be accepted as relaxing CORS on the server  does have some security implications.
